### PR TITLE
ENH restriction on overload length is too tight

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,3 +72,7 @@ jobs:
       - name: Run MPI tests 9 ranks
         run: |
           mpirun -n 9 poetry run pytest --with-mpi
+
+      - name: Run MPI tests 16 ranks
+        run: |
+          mpirun -n 16 poetry run pytest --with-mpi

--- a/mpipartition/overload.py
+++ b/mpipartition/overload.py
@@ -64,7 +64,12 @@ def overload(
     """
     assert len(coord_keys) == partition.dimensions
     for i in range(partition.dimensions):
-        assert overload_length < partition.extent[i] * box_size
+        max_overload = partition.extent[i] * box_size
+        if partition.decomposition[i] == 2:
+            # can maximally overload have the local extent, otherwise would need
+            # to send same particle multiple times
+            max_overload *= 0.5
+        assert overload_length < max_overload
 
     nranks = partition.nranks
     if nranks == 1:

--- a/mpipartition/overload.py
+++ b/mpipartition/overload.py
@@ -64,7 +64,7 @@ def overload(
     """
     assert len(coord_keys) == partition.dimensions
     for i in range(partition.dimensions):
-        assert overload_length < 0.5 * partition.extent[i] * box_size
+        assert overload_length < partition.extent[i] * box_size
 
     nranks = partition.nranks
     if nranks == 1:

--- a/mpipartition/overload.py
+++ b/mpipartition/overload.py
@@ -64,9 +64,10 @@ def overload(
     """
     assert len(coord_keys) == partition.dimensions
     for i in range(partition.dimensions):
+        assert partition.decomposition[i] > 1  # currently can't overload if only 1 rank
         max_overload = partition.extent[i] * box_size
         if partition.decomposition[i] == 2:
-            # can maximally overload have the local extent, otherwise would need
+            # can maximally overload half the local extent, otherwise would need
             # to send same particle multiple times
             max_overload *= 0.5
         assert overload_length < max_overload

--- a/tests/test_overload.py
+++ b/tests/test_overload.py
@@ -116,7 +116,9 @@ def _check_0overload(dimensions, n):
 @pytest.mark.xfail
 def test_1d_large_ol():
     partition = Partition(1)
-    ol = 0.55 * 1 / np.max(partition.decomposition)
+    if np.min(partition.decomposition) == 1:
+        pytest.xfail("invalid number of MPI ranks for overload")
+    ol = 1 / np.max(partition.decomposition)
     _check_0overload(1, 1000)
     _overloading(1, 1000, ol)
 
@@ -124,6 +126,8 @@ def test_1d_large_ol():
 @pytest.mark.mpi
 def test_1d():
     partition = Partition(1)
+    if np.min(partition.decomposition) == 1:
+        pytest.xfail("invalid number of MPI ranks for overload")
     ol = 0.49 * 1 / np.max(partition.decomposition)
     _check_0overload(1, 1000)
     _overloading(1, 1000, ol)
@@ -132,6 +136,8 @@ def test_1d():
 @pytest.mark.mpi
 def test_2d():
     partition = Partition(2)
+    if np.min(partition.decomposition) == 1:
+        pytest.xfail("invalid number of MPI ranks for overload")
     ol = 0.49 * 1 / np.max(partition.decomposition)
     _check_0overload(2, 100)
     _overloading(2, 100, ol)
@@ -140,6 +146,8 @@ def test_2d():
 @pytest.mark.mpi
 def test_3d():
     partition = Partition(3)
+    if np.min(partition.decomposition) == 1:
+        pytest.xfail("invalid number of MPI ranks for overload")
     ol = 0.49 * 1 / np.max(partition.decomposition)
     _check_0overload(3, 10)
     _overloading(3, 10, ol)
@@ -148,6 +156,8 @@ def test_3d():
 @pytest.mark.mpi
 def test_4d():
     partition = Partition(4)
+    if np.min(partition.decomposition) == 1:
+        pytest.xfail("invalid number of MPI ranks for overload")
     ol = 0.49 * 1 / np.max(partition.decomposition)
     _check_0overload(4, 4)
     _overloading(4, 4, ol)


### PR DESCRIPTION
For a single layer of other domains, we can overload up to the full length of the other domain just fine.