### PR TITLE
Enable MPIPartition to work with an input MPI communicator

### DIFF
--- a/mpipartition/partition.py
+++ b/mpipartition/partition.py
@@ -10,11 +10,6 @@ import numpy as np
 import mpi4py
 mpi4py.rc.initialize = False
 from mpi4py import MPI
-#from mpi4py import MPI
-
-#_comm = MPI.COMM_WORLD
-#_rank = _comm.Get_rank()
-#_nranks = _comm.Get_size()
 
 
 def _factorize(n):
@@ -87,7 +82,7 @@ class Partition:
 
     def __init__(
         self,
-        comm, 
+        comm=None, 
         dimensions=3,
         *,
         create_neighbor_topo: bool = False,
@@ -98,9 +93,16 @@ class Partition:
         self._neighbor_ranks = None
 
         self._dimensions = dimensions
-        self._comm = comm
-        self._rank = comm.Get_rank()
-        self._nranks = comm.Get_size()
+
+        if comm is not None:
+            self._comm = comm
+            self._mpi_init = False
+        else:
+            MPI.Init()
+            self._mpi_init = True
+            self._comm = MPI.COMM_WORLD
+        self._rank = self._comm.Get_rank()
+        self._nranks = self._comm.Get_size()
 
         assert dimensions > 0
         assert type(dimensions) == int
@@ -161,6 +163,8 @@ class Partition:
             self._neighbor_topo.Free()
         if self._topo is not None:
             self._topo.Free()
+        if self._mpi_init:
+            MPI.Finalize()
 
     @property
     def dimensions(self):


### PR DESCRIPTION
This PR consists of a few changes to the Partition class in order for it to be able to take in an input MPI communicator if needed. I think this feature is useful when Partition() is called within an MPI application which already initialized the MPI communicator.

I successfully tested both approaches with this example code in the [documentation](https://argonnecpac.github.io/MPIPartition/1_cartesian_partition/#examples). In the case where Partition() takes in the MPI communicator, one just needs to initialize MPI before importing mpipartition and pass `comm` as an input, as follows

```
from mpi4py import MPI
comm = MPI.COMM_WORLD
rank = comm.Get_rank()
size = comm.Get_size()

from mpipartition import Partition
from mpipartition import distribute, overload, exchange
...
partition = Partition(comm=comm)
...
```

Note also that the example code does not run as is, it requires a few minor fixes, namely:
- `is_valid = np.ones(n_local_after, dtype=np.bool_)` needs to be `is_valid = np.ones(n_local_distributed, dtype=np.bool_)`
- `for i, x in enumerate(['xyz']):` needs to be `for i, x in enumerate('xyz'):`

Thanks! Let me know what else I can assist with to get this PR merged, MPIPartition is a very useful package!

